### PR TITLE
Change to compile using Java 7 instead of 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
                 <version>3.1</version>
                 <!-- See http://maven.apache.org/plugins/maven-compiler-plugin -->
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/googlecode/junittoolbox/MultithreadingTester.java
+++ b/src/main/java/com/googlecode/junittoolbox/MultithreadingTester.java
@@ -101,7 +101,7 @@ public class MultithreadingTester {
         return this;
     }
 
-    private static RunnableAssert convertToRunnableAssert(@Nonnull Runnable runnable) {
+    private static RunnableAssert convertToRunnableAssert(@Nonnull final Runnable runnable) {
         return new RunnableAssert(runnable.toString()) {
             @Override
             public void run() {
@@ -123,7 +123,7 @@ public class MultithreadingTester {
         return this;
     }
 
-    private static RunnableAssert convertToRunnableAssert(@Nonnull Callable<?> callable) {
+    private static RunnableAssert convertToRunnableAssert(@Nonnull final Callable<?> callable) {
         return new RunnableAssert(callable.toString()) {
             @Override
             public void run() throws Exception {
@@ -164,9 +164,9 @@ public class MultithreadingTester {
         me.throwIfNotEmpty();
     }
 
-    private void startMonitorThread(MultiException me) {
-        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        Set<Long> knownDeadlockedThreadIds = asSet(threadMXBean.findDeadlockedThreads());
+    private void startMonitorThread(final MultiException me) {
+        final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        final Set<Long> knownDeadlockedThreadIds = asSet(threadMXBean.findDeadlockedThreads());
         monitorThread = new Thread("MultithreadingTester-monitor") {
             @Override
             public void run() {
@@ -199,15 +199,15 @@ public class MultithreadingTester {
         monitorThread.start();
     }
 
-    private void startWorkerThreads(MultiException me) {
+    private void startWorkerThreads(final MultiException me) {
         workerThreads = new Thread[numThreads];
         Iterator<RunnableAssert> i = runnableAsserts.iterator();
-        CountDownLatch latch = new CountDownLatch(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
         for (int j = 0; j < numThreads; ++j) {
             if (!i.hasNext()) {
                 i = runnableAsserts.iterator();
             }
-            RunnableAssert runnableAssert = i.next();
+            final RunnableAssert runnableAssert = i.next();
             Thread workerThread = new Thread("MultithreadingTester-worker-" + (j + 1)) {
                 @Override
                 public void run() {

--- a/src/main/java/com/googlecode/junittoolbox/ParallelRunner.java
+++ b/src/main/java/com/googlecode/junittoolbox/ParallelRunner.java
@@ -95,7 +95,7 @@ public class ParallelRunner extends Theories {
         @Override
         protected void runWithIncompleteAssignment(Assignments incomplete) throws Throwable {
             for (PotentialAssignment source : incomplete.potentialsForNextUnassigned()) {
-                Assignments nextAssignment = incomplete.assignNext(source);
+                final Assignments nextAssignment = incomplete.assignNext(source);
                 ForkJoinTask<?> asyncRun = new RecursiveAction() {
                     @Override
                     protected void compute() {

--- a/src/main/java/com/googlecode/junittoolbox/PollingWait.java
+++ b/src/main/java/com/googlecode/junittoolbox/PollingWait.java
@@ -125,7 +125,7 @@ public class PollingWait {
      *
      * @since 2.0
      */
-    public void until(@Nonnull Callable<Boolean> shouldBeTrue) {
+    public void until(@Nonnull final Callable<Boolean> shouldBeTrue) {
         until(new RunnableAssert(shouldBeTrue.toString()) {
             @Override
             public void run() throws Exception {

--- a/src/main/java/com/googlecode/junittoolbox/WildcardPatternSuite.java
+++ b/src/main/java/com/googlecode/junittoolbox/WildcardPatternSuite.java
@@ -68,9 +68,9 @@ public class WildcardPatternSuite extends Suite {
     private static Class<?>[] findSuiteClasses(Class<?> klass, String... wildcardPatterns) throws InitializationError {
         File baseDir = getBaseDir(klass);
         try {
-            String basePath = baseDir.getCanonicalPath().replace('\\', '/');
-            List<Pattern> includePatterns = new ArrayList<>();
-            List<Pattern> excludePatterns = new ArrayList<>();
+            final String basePath = baseDir.getCanonicalPath().replace('\\', '/');
+            final List<Pattern> includePatterns = new ArrayList<>();
+            final List<Pattern> excludePatterns = new ArrayList<>();
             for (String wildcardPattern : wildcardPatterns) {
                 if (wildcardPattern == null) {
                     throw new InitializationError("wildcard pattern for the SuiteClasses annotation must not be null");


### PR DESCRIPTION
I noticed the source and target Java version jumped from 6 to 8 from 1.9 to 2.0, but the source is still compatible with Java 7 except for a few missing final keywords.  If you intend to use Java 8 language features, please feel free to reject this pull request; otherwise these changes will enable people stuck on Java 7 to use and contribute to your project.